### PR TITLE
fix: Conditional CD4% Rendering for Children <= 5yrs and Validation Enhancement

### DIFF
--- a/apps/labpulse/views.py
+++ b/apps/labpulse/views.py
@@ -66,12 +66,12 @@ def disable_update_buttons(request, audit_team, relevant_date_field):
                         data.hide_update_button = False
             except AttributeError:
                 messages.info(request,
-                              "You have not yet set the time to disable the DQA update button. Please click on the 'Change "
-                              "DQA Update Time' button on the left navigation bar to set the time or contact an "
-                              "administrator to set it for you.")
+                              "You have not yet set the time to disable the LabPulse update button. Please click on the"
+                              " 'Change DQA Update Time' button on the left navigation bar to set the time or contact "
+                              "an administrator to set it for you.")
     except AttributeError:
         messages.info(request,
-                      "You have not yet set the time to disable the DQA update button. Please click on the 'Change "
+                      "You have not yet set the time to disable the LabPulse update button. Please click on the 'Change "
                       "labPulse Update Time' button on the left navigation bar to set the time or contact an "
                       "administrator to set it for you.")
     return redirect(request.path_info)
@@ -214,6 +214,18 @@ def add_cd4_count(request, pk_lab):
 
                 if age <= 5 and not cd4_percentage:
                     error_message = f"Please provide CD4 % values for {patient_unique_no}"
+                    form.add_error('age', error_message)
+                    form.add_error('cd4_percentage', error_message)
+                    return render(request, template_name, context)
+
+                if age > 5 and cd4_percentage:
+                    error_message = f"CD4 % values ought to be for <=5yrs."
+                    form.add_error('age', error_message)
+                    form.add_error('cd4_percentage', error_message)
+                    return render(request, template_name, context)
+
+                if age <= 5 and cd4_percentage > 100:
+                    error_message = f"Invalid CD4 % values"
                     form.add_error('age', error_message)
                     form.add_error('cd4_percentage', error_message)
                     return render(request, template_name, context)
@@ -372,6 +384,18 @@ def update_cd4_results(request, pk):
 
                 if age <= 5 and not cd4_percentage:
                     error_message = f"Please provide CD4 % values for {patient_unique_no}"
+                    form.add_error('age', error_message)
+                    form.add_error('cd4_percentage', error_message)
+                    return render(request, template_name, context)
+
+                if age > 5 and cd4_percentage:
+                    error_message = f"CD4 % values ought to be for <=5yrs."
+                    form.add_error('age', error_message)
+                    form.add_error('cd4_percentage', error_message)
+                    return render(request, template_name, context)
+
+                if age <= 5 and cd4_percentage > 100:
+                    error_message = f"Invalid CD4 % values"
                     form.add_error('age', error_message)
                     form.add_error('cd4_percentage', error_message)
                     return render(request, template_name, context)

--- a/assets/templates/lab_pulse/show results.html
+++ b/assets/templates/lab_pulse/show results.html
@@ -322,11 +322,12 @@
                                             <p class="fw-bold text-danger"
                                                style="font-size: xx-small">{{ result.reason_for_rejection }}</p>
                                         {% else %}
-                                            {% if result.cd4_count_results <= 200 %}
+                                            {% if result.age > 5 and result.cd4_count_results <= 200 %}
                                                 <p class="fw-bold"
                                                    style="font-size: small">{{ result.cd4_count_results }}</p>
                                             {% elif result.age <= 5 %}
-                                                {{ result.cd4_count_results }}
+                                                <p class="fw-bold"
+                                                   style="font-size: small">{{ result.cd4_count_results }}</p>
                                                 <br>
                                                 <span style="font-size: 8px" class="badge alert-info">
                                                     CD4 percentage: {{ result.cd4_percentage }}%


### PR DESCRIPTION
This PR introduces essential updates to our branch, explicitly targeting the rendering and validation of CD4% values for children aged 5 years and below. The changes implemented in this PR enhance the accuracy and reliability of CD4% data entry, ensuring that only valid values are accepted and displayed for this specific age group.

### Key Changes:

**Conditional CD4% Rendering:** The current branch now renders CD4% conditionally for children aged 5 years and below, ensuring a more intuitive and relevant user experience.

**CD4% Validation Enhancement:** Besides the conditional rendering, this PR implements enhanced validation for CD4% values. Specifically, the validation logic has been updated to ensure that CD4% values entered for children aged 5 years and below are within the valid range of 0% to 100%. Any value outside this range will be flagged as an error, prompting the user to correct it.

These updates aim to improve data accuracy and consistency in CD4% measurements for children aged 5 years and below. By rendering the CD4% field conditionally and implementing stricter validation, we can ensure that only appropriate and valid values are recorded, avoiding potential data discrepancies or errors.

Peter
