### PR TITLE
save cd4 when 'use_commodities' flag is false

### DIFF
--- a/apps/labpulse/views.py
+++ b/apps/labpulse/views.py
@@ -554,7 +554,7 @@ def add_cd4_count(request, report_type, pk_lab):
             if not validate_cd4_count_form(form, report_type):
                 # If validation fails, return the form with error messages
                 return render(request, template_name, context)
-            if report_type == "Current":
+            if report_type == "Current" and use_commodities:
                 # Call the function to handle serum_crag_results and tb_lam_results errors
                 error_response = handle_commodity_errors(request, form, crag_total_remaining, tb_lam_total_remaining,
                                                          template_name, context)
@@ -756,7 +756,7 @@ def update_cd4_results(request, report_type, pk):
             if not validate_cd4_count_form(form, report_type):
                 # If validation fails, return the form with error messages
                 return render(request, template_name, context)
-            if report_type == "Current":
+            if report_type == "Current" and use_commodities:
                 # Call the function to handle serum_crag_results and tb_lam_results errors
                 error_response = handle_commodity_errors(request, form, crag_total_remaining, tb_lam_total_remaining,
                                                          template_name, context)


### PR DESCRIPTION
**Description:**
This pull request introduces crucial enhancements to the application's codebase, ensuring that CD4 results, sCrAg, and TB LAM can be saved when the "use_commodities" flag is set to False by the admin. These changes provide greater flexibility and usability to the application, accommodating a wider range of scenarios.

**Changes Made:**

Compatibility for Saving CD4 Results, sCrAg, and TB LAM:
The application's codebase has been updated to allow the saving of CD4 results, sCrAg, and TB LAM even when the "use_commodities" flag is set to False by the admin.
This change ensures that essential data can be recorded and managed seamlessly, irrespective of the "use_commodities" configuration.
