### PR TITLE
fix: Access dqa_dashboard/{dqa-type} db error

### DIFF
--- a/apps/dqa/views.py
+++ b/apps/dqa/views.py
@@ -4132,8 +4132,10 @@ def generate_missing_indicators_message(data_verification_data, model_name, inte
     else:
         return None  # No missing indicators
 
-
+@login_required(login_url='login')
 def dqa_dashboard(request, dqa_type=None):
+    if not request.user.first_name:
+        return redirect("profile")
     if request.method == "GET":
         request.session['page_from'] = request.META.get('HTTP_REFERER', '/')
 


### PR DESCRIPTION
**Description:**
This pull request enhances the security of the DQA (Data Quality Assessment) Dashboard view by adding the @login_required decorator. This ensures that only authenticated users can access the DQA Dashboard, redirecting unauthenticated users to the login page.

**Changes Made:**
_Login Requirement Decorator:_
Added the @login_required(login_url='login') decorator to the dqa_dashboard view function.

**Benefits:**
_Enhanced Security:_
By requiring authentication, the DQA Dashboard is now more secure, ensuring that only authorized users can access sensitive data.
_User Redirection:_
Unauthenticated users are automatically redirected to the login page, promoting a seamless and secure user experience.