### PR TITLE
Fix: Prevent double submission of the login page

### DIFF
--- a/assets/templates/account/login_page.html
+++ b/assets/templates/account/login_page.html
@@ -91,7 +91,7 @@
                 <h3 id="form-title">LOGIN</h3>
             </div>
             <div class="d-flex justify-content-center form_container">
-                <form method="POST" action="">
+                <form method="POST" action="" onsubmit="return preventDoubleSubmission()">
                     {% csrf_token %}
                     <div class="input-group mb-3">
                         <div class="input-group-append">
@@ -113,8 +113,9 @@
                         </div>
                     </div>
                     <div class="d-flex justify-content-center mt-3 login_container">
-                        <input class="btn login_btn" type="submit" value="Login">
+                        <input class="btn login_btn" type="submit" value="Login" id="submitButton">
                     </div>
+                    <div id="submitButtonMessage" style="margin-left: 10px;"></div>
                 </form>
             </div>
 
@@ -146,6 +147,18 @@
             passwordIcon.classList.remove('fa-eye-slash');
             passwordIcon.classList.add('fa-eye');
         }
+    }
+
+    function preventDoubleSubmission() {
+        const submitButton = document.getElementById("submitButton");
+        const submitButtonMessage = document.getElementById("submitButtonMessage");
+
+        submitButton.disabled = true; // Disable the submit button
+        {#submitButtonMessage.innerHTML = "Login button is disabled. Please wait for the submission to complete.";#}
+        submitButtonMessage.innerHTML = '<i class="fas fa-spinner fa-spin">' +
+            '</i> Please wait while we process your login or reload the page to start a fresh login.';
+        // Ensure the form is submitted only once
+        return true;
     }
 </script>
 


### PR DESCRIPTION
**Description:**
This pull request introduces a feature to prevent double submission in the login form. It disables the submit button upon form submission and provides visual feedback to the user, addressing potential issues related to multiple submissions that could lead to a Forbidden (403) error.

**Changes Made:**
_Added preventDoubleSubmission Function:_
Introduced the preventDoubleSubmission JavaScript function to disable the submit button and display a spinner icon and a message upon form submission.

_Updated HTML Form:_
Added the onsubmit="return preventDoubleSubmission()" attribute to the HTML form, linking it to the JavaScript function.

**Benefits:**
_Preventing Double Submission:_
The implemented solution ensures that the login form cannot be submitted multiple times, preventing potential issues such as a Forbidden (403) error.
_User Feedback:_
Visual feedback in the form of a disabled submit button and a spinner icon with a message informs the user that the form submission is in progress.