### PR TITLE
Fix: Improving Image Resize Function with Case Insensitivity

### DIFF
--- a/apps/cqi/utils.py
+++ b/apps/cqi/utils.py
@@ -25,7 +25,7 @@ def image_resize(image, width, height):
             # Find the file name of the image
             img_filename = Path(image.file.name).name
             # Spilt the filename on “.” to get the file extension only
-            img_suffix = Path(image.file.name).name.split(".")[-1]
+            img_suffix = Path(image.file.name).name.split(".")[-1].lower()
             # Use the file extension to determine the file type from the image_types dictionary
             img_format = image_types[img_suffix]
             # Save the resized image into the buffer, noting the correct file type


### PR DESCRIPTION
**Description:**
This pull request enhances the image_resize function by introducing case insensitivity when determining the file type from the image file extension. This is achieved by converting the file extension to lowercase, preventing potential key errors when accessing the image_types dictionary.

**Changes Made:**
_Added Case Insensitivity:_
Introduced the .lower() method to the file extension when determining the file type from the image_types dictionary.

**Benefits:**
_Preventing Key Errors:_
The addition of case insensitivity ensures that file extensions are treated in a case-insensitive manner, preventing potential key errors in the image_types dictionary.