### PR TITLE
Fix: Addressing N+1 Query in Cd4traker Download View

### DIFF
--- a/apps/labpulse/views.py
+++ b/apps/labpulse/views.py
@@ -1596,7 +1596,10 @@ def show_results(request):
     # Access the page URL
     current_page_url = request.path
 
-    cd4traker_qs = Cd4traker.objects.all().order_by('-date_dispatched')
+    # Handle N+1 Query /lab-pulse/download/{filter_type}
+    cd4traker_qs = Cd4traker.objects.all().prefetch_related('facility_name', 'sub_county', 'county',
+                                                            'testing_laboratory', 'created_by', 'modified_by'
+                                                            ).order_by('-date_dispatched')
     # Calculate TAT in days and annotate it in the queryset
     queryset = cd4traker_qs.annotate(
         tat_days=ExpressionWrapper(


### PR DESCRIPTION
**Description:**
This pull request addresses the N+1 query issue in the Cd4traker download view by incorporating .prefetch_related for related fields. The changes aim to optimize database queries, improve performance, and avoid the N+1 query problem.

**Changes Made:**
_Added .prefetch_related:_
Introduced .prefetch_related for related fields in the Cd4traker download view to handle N+1 query issues.

**Benefits:**
_Query Optimization:_
Adding .prefetch_related optimizes database queries, addresses N+1 query issues, and enhances performance.
