### PR TITLE
Cached the RTK viz view

### DIFF
--- a/assets/templates/data_analysis/rtk_viz.html
+++ b/assets/templates/data_analysis/rtk_viz.html
@@ -143,57 +143,6 @@
                     </form>
                 </div>
                 <hr>
-                {#                {% if qi_list %}#}
-                <div class="row">
-                    <div class="col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2 mb-2">
-                        <a href="{% url 'download_csv_lab' "all" %}?{{ request.GET.urlencode }}"
-                           class="btn btn-secondary btn-block" role="button"> All records
-                            <i class="fas fa-download"></i>
-                        </a>
-                    </div>
-                    {% if rejected_samples_exist %}
-                        <div class="col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2 mb-2">
-                            <a href="{% url 'download_csv_lab' "rejected" %}?{{ request.GET.urlencode }}"
-                               class="btn btn-secondary btn-block" role="button"> Rejected samples
-                                <i class="fas fa-download"></i>
-                            </a>
-                        </div>
-                    {% endif %}
-                    {% if tb_lam_pos_samples_exist %}
-                        <div class="col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2 mb-2">
-                            <a href="{% url 'download_csv_lab' "positive_tb_lam" %}?{{ request.GET.urlencode }}"
-                               class="btn btn-secondary btn-block" role="button"> Positive TB LAM
-                                <i class="fas fa-download"></i>
-                            </a>
-                        </div>
-                    {% endif %}
-                    {% if crag_pos_samples_exist %}
-                        <div class="col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2 mb-2">
-                            <a href="{% url 'download_csv_lab' "positive_crag" %}?{{ request.GET.urlencode }}"
-                               class="btn btn-secondary btn-block" role="button"> Positive CrAg
-                                <i class="fas fa-download"></i>
-                            </a>
-                        </div>
-                    {% endif %}
-                    {% if missing_crag_samples_exist %}
-                        <div class="col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2 mb-2">
-                            <a href="{% url 'download_csv_lab' filter_type='missing_crag' %}?{{ request.GET.urlencode }}"
-                               class="btn btn-secondary btn-block" role="button"> Missing CrAg
-                                <i class="fas fa-download"></i>
-                            </a>
-                        </div>
-                    {% endif %}
-                    {% if missing_tb_lam_samples_exist %}
-                        <div class="col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2 mb-2">
-                            <a href="{% url 'download_csv_lab' "missing_tb_lam" %}?{{ request.GET.urlencode }}"
-                               class="btn btn-secondary btn-block" role="button"> Missing TB LAM
-                                <i class="fas fa-download"></i>
-                            </a>
-                        </div>
-                    {% endif %}
-                </div>
-                {#                    {% if title == "Results" %}#}
-                <hr>
                 <h4 class="fw-bold text-primary text-center"> Summary </h4>
                 <hr>
                 <div class="container">


### PR DESCRIPTION
**Description:**
This pull request aims to optimize the caching mechanism for the RTK data visualization view. The key improvement is to cache the entire rendered view for a specified duration, reducing redundant computations and database queries.

**Changes Made:**
_Cache Key Generation:_
Generated a cache key using a hash of relevant data such as DataFrame content and request parameters.
_Cache Check:_
Checked if the view is already cached using the generated cache key.
_Rendering View:_
If the view is not cached, rendered the view using the filtered queryset and context.
_Cache Set:_
Cached the entire rendered view with the generated cache key for 30 days.

**Benefits:**
_Reduced Database Queries:_
By caching the entire rendered view, redundant database queries and computations are minimized, leading to improved performance.
_Faster Response Time:_
Users will experience faster response times as the view is served from the cache when available.
_Efficient Resource Utilization:_
Resources are utilized more efficiently, especially for static data that doesn't change within the month.