### PR TITLE
Add viral tracker

### DIFF
--- a/apps/data_analysis/forms.py
+++ b/apps/data_analysis/forms.py
@@ -10,11 +10,18 @@ class DateFilterForm(forms.Form):
 
 
 class FileUploadForm(forms.Form):
-    file = forms.FileField()
+    file = forms.FileField(label="File")
+
+
+class EmrFileUploadForm(forms.Form):
+    file1 = forms.FileField(label="File")
+
+
 class MultipleUploadForm(forms.Form):
     files = MultiFileField(min_num=1, max_num=12,
                            # max_file_size=1024 * 1024 * 5
                            )  # Adjust max_num and max_file_size as needed
+
 
 class DataFilterForm(forms.Form):
     CHOICES = [

--- a/apps/data_analysis/urls.py
+++ b/apps/data_analysis/urls.py
@@ -2,7 +2,7 @@ from django.urls import include, path
 
 from apps.data_analysis.views import UploadRTKDataView, pharmacy, download_csv, load_fyj_censused, rtk_inventory_viz, \
     rtk_visualization, \
-    tat, fmaps_reporting_rate, viral_load
+    tat, fmaps_reporting_rate, viral_load, viral_track
 
 urlpatterns = [
     path('pharmacy/', pharmacy, name="load_data_pharmacy"),
@@ -10,6 +10,7 @@ urlpatterns = [
     path('load-fyj-censused-facilities', load_fyj_censused, name='load_fyj_censused'),
     path('fmaps-reporting-rate', fmaps_reporting_rate, name='fmaps_reporting_rate'),
     path('viral-load', viral_load, name='viral_load'),
+    path('viratrack/', viral_track, name='viral_track'),
     path('tat', tat, name='tat'),
     path('upload-rtks-data/', UploadRTKDataView.as_view(), name='upload_rtk'),
     path('rtk-visualization/', rtk_visualization, name='rtk_visualization'),

--- a/assets/templates/data_analysis/rtk_viz.html
+++ b/assets/templates/data_analysis/rtk_viz.html
@@ -31,6 +31,12 @@
                     {% else %}
                         <a href="{% url 'viral_load' %}" class="btn btn-outline-success">VL Analyzer</a>
                     {% endif %}
+                    {% if dqa_type == "viral track" %}
+                        <a href="{% url 'viral_track' %}" class="btn btn-success">Viral Track</a>
+                    {% else %}
+
+                        <a href="{% url 'viral_track' %}" class="btn btn-outline-success">Viral Track</a>
+                    {% endif %}
                     {% if dqa_type == "rtk" %}
                         <a href="{% url 'rtk_visualization' %}" class="btn btn-success">HCMP: Opening vs Closing bal</a>
                     {% else %}

--- a/assets/templates/data_analysis/tat.html
+++ b/assets/templates/data_analysis/tat.html
@@ -28,6 +28,12 @@
                     {% else %}
                         <a href="{% url 'viral_load' %}" class="btn btn-outline-success">VL Analyzer</a>
                     {% endif %}
+                    {% if dqa_type == "viral track" %}
+                        <a href="{% url 'viral_track' %}" class="btn btn-success">Viral Track</a>
+                    {% else %}
+
+                        <a href="{% url 'viral_track' %}" class="btn btn-outline-success">Viral Track</a>
+                    {% endif %}
                     {% if dqa_type == "rtk" %}
                         <a href="{% url 'rtk_visualization' %}" class="btn btn-success">HCMP REPORT</a>
                     {% else %}

--- a/assets/templates/data_analysis/viral_tracker.html
+++ b/assets/templates/data_analysis/viral_tracker.html
@@ -1,0 +1,279 @@
+{% extends 'data_analysis/index_dqa.html' %}
+{% load crispy_forms_filters %}
+{% load crispy_forms_tags %}
+{% load static %}
+
+
+{% block content %}
+    <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+        <div class="p-5 mb-4 bg-light rounded-3">
+            <div>
+                <div class="container-fluid py-5">
+                    {% if messages %}
+                        {% for message in messages|slice:":1" %}
+                            <div class="alert alert-info col-12" role="alert">
+                                <h6 style="font-size: x-small">
+                                    {{ message|safe }}
+                                </h6>
+                            </div>
+                        {% endfor %}
+                    {% endif %}
+                    <div class="d-flex justify-content-around mb-3">
+                        {% if dqa_type == "tat" %}
+                            <a href="{% url 'tat' %}" class="btn btn-success">Turn Around Time (TAT)</a>
+                        {% else %}
+                            <a href="{% url 'tat' %}" class="btn btn-outline-success">Turn Around Time (TAT)</a>
+                        {% endif %}
+                        {% if dqa_type == "viral_load" %}
+                            <a href="{% url 'viral_load' %}" class="btn btn-success">VL Analyzer</a>
+                        {% else %}
+                            <a href="{% url 'viral_load' %}" class="btn btn-outline-success">VL Analyzer</a>
+                        {% endif %}
+                        {% if dqa_type == "viral track" %}
+                            <a href="{% url 'viral_track' %}" class="btn btn-success">Viral Track</a>
+                        {% else %}
+                            <a href="{% url 'viral_track' %}" class="btn btn-outline-success">Viral Track</a>
+                        {% endif %}
+                        {% if dqa_type == "rtk" %}
+                            <a href="{% url 'rtk_visualization' %}" class="btn btn-success">HCMP REPORT</a>
+                        {% else %}
+
+                            <a href="{% url 'rtk_visualization' %}" class="btn btn-outline-success">HCMP REPORT</a>
+                        {% endif %}
+                    </div>
+                    <form method="post" id="filter-form" enctype="multipart/form-data" class="mt-5">
+                        {% csrf_token %}
+                        <div class="container">
+                            <div class="row align-items-center">
+                                <div class="col-md-3 text-center">
+                                    <img class="img-fluid" src="{% static 'images/lab.png' %}" alt="Lab Image"
+                                         width="200">
+                                </div>
+                                <div class="col-md-9">
+                                    <div class="row">
+                                        <div class="col mb-4">
+                                            <h3 class="text-primary">{{ target_text }} Viral Tracker</h3>
+                                        </div>
+                                    </div>
+                                    <div class="row">
+                                        <div class="col">
+                                            <p><strong>Instructions:</strong></p>
+                                            <ol class="mb-4">
+                                                <li>Log in to the <a href="https://eiddash.nascop.org/reports/VL"
+                                                                     target="_blank">NASCOP's website</a> and download
+                                                    the overall Detailed (Viral Load) CSV (one year ago data from the
+                                                    current month).
+                                                </li>
+                                                <li>Recreate tables in KenyaEMR and download the Active on ART Patients
+                                                    Line list.csv.
+                                                </li>
+                                                <li>Upload the overall Detailed (Viral Load) CSV file from NASCOP's
+                                                    website and the updated Active on ART Patients Linelist.csv from
+                                                    KenyaEMR.
+                                                </li>
+                                                <li>Click "Submit".</li>
+                                            </ol>
+                                        </div>
+                                    </div>
+                                    <div class="row">
+                                        <div class="col-md-6 mb-3">
+                                            <label for="id_file1" class="form-label">KenyaEMR (Active on ART Patients
+                                                Linelist):</label>
+                                            <div class="input-group">
+                                                {{ form_emr.file1|as_crispy_field }}
+                                                {% if form_emr.file1.value %}
+                                                    <p class="form-text text-muted">Uploaded
+                                                        File: {{ form_emr.file1.value.name }}</p>
+                                                {% endif %}
+                                            </div>
+                                        </div>
+                                        <div class="col-md-6 mb-3">
+                                            <label for="id_file" class="form-label">NASCOP's (Overall Detailed VL
+                                                report):</label>
+                                            <div class="input-group">
+                                                {{ form.file|as_crispy_field }}
+                                                {% if form.file.value %}
+                                                    <p class="form-text text-muted">Uploaded
+                                                        File: {{ form.file.value.name }}</p>
+                                                {% endif %}
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="row mt-3">
+                                        <div class="col text-center">
+                                            <button type="submit" class="btn btn-primary">Submit</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+                <div class="row">
+                    <!-- Row with 4 buttons -->
+                    {% if not backlog_df.empty %}
+                        <div class="col-3 p-2">
+                            <a href="{% url 'download_csv' dictionary.backlog_df "vl_backlog" %}">
+                                <button type="button" class="btn btn-secondary btn-floating w-100"
+                                        data-mdb-ripple-color="dark">
+                                    VL backlog (All) <i class="fas fa-download"></i>
+                                </button>
+                            </a>
+                        </div>
+                    {% endif %}
+
+                    {% if not discordant_results.empty %}
+                        <div class="col-3 p-2">
+                            <a href="{% url 'download_csv' dictionary.discordant_results "discordant_results" %}">
+                                <button type="button" class="btn btn-secondary btn-floating w-100"
+                                        data-mdb-ripple-color="dark">
+                                    Discordant VL report <i class="fas fa-download"></i>
+                                </button>
+                            </a>
+                        </div>
+                    {% endif %}
+
+                    {% if not results_not_in_nascop_overall.empty %}
+                        <div class="col-3 p-2">
+                            <a href="{% url 'download_csv' dictionary.results_not_in_nascop_overall "results_not_in_nascop_overall" %}">
+                                <button type="button" class="btn btn-secondary btn-floating w-100"
+                                        data-mdb-ripple-color="dark">
+                                    VL results missing in NASCOP website <i class="fas fa-download"></i>
+                                </button>
+                            </a>
+                        </div>
+                    {% endif %}
+
+                    {% if not missing_in_emr.empty %}
+                        <div class="col-3 p-2">
+                            <a href="{% url 'download_csv' dictionary.missing_in_emr "missing_in_emr" %}">
+                                <button type="button" class="btn btn-secondary btn-floating w-100"
+                                        data-mdb-ripple-color="dark">
+                                    VL Missing in EMR <i class="fas fa-download"></i>
+                                </button>
+                            </a>
+                        </div>
+                    {% endif %}
+                </div>
+
+            </div>
+        </div>
+        <hr>
+        <div class="container">
+            <div class="row">
+                {% if vl_backlog_fig %}
+                    <div class="col-12 mb-4">
+                        {{ vl_uptake_fig|safe }}
+                    </div>
+                    <hr>
+                {% endif %}
+                {% if vl_backlog_fig %}
+                    <div class="col-12 mb-4">
+                        {{ vl_backlog_fig|safe }}
+                    </div>
+                    <hr>
+                {% endif %}
+                {% if vl_backlog_detailed_fig %}
+                    <div class="col-12 mb-4">
+                        {{ vl_backlog_detailed_fig|safe }}
+                    </div>
+                    <div class="row">
+                        <!-- Row 1 -->
+                        {% if not no_vl_ever.empty %}
+                            <div class="col-3 p-2">
+                                <a href="{% url 'download_csv' dictionary.no_vl_ever "no_vl_ever" %}">
+                                    <button type="button" class="btn btn-secondary btn-floating w-100"
+                                            data-mdb-ripple-color="dark">
+                                        No VL ever <i class="fas fa-download"></i>
+                                    </button>
+                                </a>
+                            </div>
+                        {% endif %}
+
+                        {% if not missed_12mons_above_25yrs.empty %}
+                            <div class="col-3 p-2">
+                                <a href="{% url 'download_csv' dictionary.missed_12mons_above_25yrs "missed_12mons_above_25yrs" %}">
+                                    <button type="button" class="btn btn-secondary btn-floating w-100"
+                                            data-mdb-ripple-color="dark">
+                                        Missed 12 months VL (>= 25yrs) <i class="fas fa-download"></i>
+                                    </button>
+                                </a>
+                            </div>
+                        {% endif %}
+
+                        {% if not missed_6mons_zero_24yrs.empty %}
+                            <div class="col-3 p-2">
+                                <a href="{% url 'download_csv' dictionary.missed_6mons_zero_24yrs "missed_6mons_zero_24yrs" %}">
+                                    <button type="button" class="btn btn-secondary btn-floating w-100"
+                                            data-mdb-ripple-color="dark">
+                                        Missed 6 months VL (0-24 yrs) <i class="fas fa-download"></i>
+                                    </button>
+                                </a>
+                            </div>
+                        {% endif %}
+
+                        {% if not missed_6mons_pregnant.empty %}
+                            <div class="col-3 p-2">
+                                <a href="{% url 'download_csv' dictionary.missed_6mons_pregnant "missed 6months pg and bf" %}">
+                                    <button type="button" class="btn btn-secondary btn-floating w-100"
+                                            data-mdb-ripple-color="dark">
+                                        Missed 6 months VL (pg/bf) <i class="fas fa-download"></i>
+                                    </button>
+                                </a>
+                            </div>
+                        {% endif %}
+                    </div>
+
+                    <div class="row">
+                        <!-- Row 2 -->
+                        {% if not hvl_df.empty %}
+                            <div class="col-3 p-2">
+                                <a href="{% url 'download_csv' dictionary.hvl_df "hvl" %}">
+                                    <button type="button" class="btn btn-secondary btn-floating w-100"
+                                            data-mdb-ripple-color="dark">
+                                        HVL (All) <i class="fas fa-download"></i>
+                                    </button>
+                                </a>
+                            </div>
+                        {% endif %}
+                        {% if not hvl_above_25yrs.empty %}
+                            <div class="col-3 p-2">
+                                <a href="{% url 'download_csv' dictionary.hvl_above_25yrs "hvl_above_25yrs" %}">
+                                    <button type="button" class="btn btn-secondary btn-floating w-100"
+                                            data-mdb-ripple-color="dark">
+                                        HVL (>=25 yrs) <i class="fas fa-download"></i>
+                                    </button>
+                                </a>
+                            </div>
+                        {% endif %}
+                        {% if not hvl_zero_24yrs.empty %}
+                            <div class="col-3 p-2">
+                                <a href="{% url 'download_csv' dictionary.hvl_zero_24yrs "hvl_zero_24yrs" %}">
+                                    <button type="button" class="btn btn-secondary btn-floating w-100"
+                                            data-mdb-ripple-color="dark">
+                                        HVL (0-24yrs) <i class="fas fa-download"></i>
+                                    </button>
+                                </a>
+                            </div>
+                        {% endif %}
+                        {% if not hvl_pregnant.empty %}
+                            <div class="col-3 p-2">
+                                <a href="{% url 'download_csv' dictionary.hvl_pregnant "hvl_pregnant" %}">
+                                    <button type="button" class="btn btn-secondary btn-floating w-100"
+                                            data-mdb-ripple-color="dark">
+                                        HVL (pg/bf) <i class="fas fa-download"></i>
+                                    </button>
+                                </a>
+                            </div>
+                        {% endif %}
+                    </div>
+                {% endif %}
+                {% if vl_cascade_fig %}
+                    <div class="col-12">
+                        {{ vl_cascade_fig|safe }}
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    </main>
+{% endblock %}

--- a/assets/templates/data_analysis/vl.html
+++ b/assets/templates/data_analysis/vl.html
@@ -28,6 +28,12 @@
                         {% else %}
                             <a href="{% url 'viral_load' %}" class="btn btn-outline-success">VL Analyzer</a>
                         {% endif %}
+                        {% if dqa_type == "viral track" %}
+                            <a href="{% url 'viral_track' %}" class="btn btn-success">Viral Track</a>
+                        {% else %}
+
+                            <a href="{% url 'viral_track' %}" class="btn btn-outline-success">Viral Track</a>
+                        {% endif %}
                         {% if dqa_type == "rtk" %}
                             <a href="{% url 'rtk_visualization' %}" class="btn btn-success">HCMP REPORT</a>
                         {% else %}


### PR DESCRIPTION
Description:
This pull request introduces the "viral_track" view to the Data Analysis Center app. This new view is designed to help users easily compare the active patient line list from Kenya EMR and NASCOP Viral Load results. The automation creates a line list of viral load (VL) backlog, missing data in Kenya EMR, and missing data on the NASCOP website. It also includes visualizations of VL uptake and backlog. Users can upload the two datasets, and the analysis is performed automatically.

Changes Made:
View Addition:
Introduced the viral_track view within the Data Analysis Center app. This view handles the comparison between the Kenya EMR and NASCOP Viral Load datasets.
Data Upload and Processing:
Added functionality for users to upload two datasets: the active patient line list from Kenya EMR and NASCOP Viral Load results.
Implemented data processing logic to analyze the uploaded datasets and identify VL backlog, missing data in Kenya EMR, and missing data on the NASCOP website.
Visualization:
Integrated visualizations to depict VL uptake and backlog, providing users with clear insights into the data discrepancies and backlog status.